### PR TITLE
Updated README.md Changed Docker compose example from "WORLD" to "WOR…

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ services:
     volumes:
       - /opt/terrariaServer/:/opt/terraria/config/
     environment:
-      WORLD: "myworld"
+      WORLDNAME: "myworld"
 ```
 
 ## Healthcheck


### PR DESCRIPTION
Changed Docker compose example from `WORLD` to `WORLDNAME` to match the documentation in the "2. Server environment variables" section.

I was having issues with the container not changing the default world name value until I noticed this issue in the example code block.