### PR TITLE
Update tmodloader-check.yml to get max release by published_at instead of created_at

### DIFF
--- a/.github/workflows/tmodloader-check.yml
+++ b/.github/workflows/tmodloader-check.yml
@@ -42,9 +42,9 @@ jobs:
 
           curl -s https://api.github.com/repos/tModLoader/tModLoader/releases > output.txt
           if [ "$TYPE" == "prerelease" ]; then
-            VERSION=$(jq -r '[.[] | select(.tag_name | contains("'"${YEAR}"'")) | select(.prerelease == true)] | max_by(.created_at) | .tag_name | sub("^v";"")' output.txt)
+            VERSION=$(jq -r '[.[] | select(.tag_name | contains("'"${YEAR}"'")) | select(.prerelease == true)] | max_by(.published_at) | .tag_name | sub("^v";"")' output.txt)
           else
-            VERSION=$(jq -r '[.[] | select(.tag_name | contains("'"${YEAR}"'")) | select(.prerelease == false)] | max_by(.created_at) | .tag_name | sub("^v";"")' output.txt)
+            VERSION=$(jq -r '[.[] | select(.tag_name | contains("'"${YEAR}"'")) | select(.prerelease == false)] | max_by(.published_at) | .tag_name | sub("^v";"")' output.txt)
           fi
 
           UPSTREAM=$(curl -s "https://hub.docker.com/v2/repositories/passivelemon/terraria-docker/tags/tmodloader-${VERSION}")


### PR DESCRIPTION


Right now the lastest released tmodloader version is `v2025.10.3.1`, which was created at `2025-11-20T14:25:35Z` but published at `2025-12-01T18:10:22Z`. However the release that the github action grabs is `v2025.09.3.4`, which was created at `2025-11-20T14:27:39Z` (newer) yet published at `2025-11-20T14:36:35Z`.

Sorting by publish date should be more appropriate than by created date, since a release can be created but not published for a while, which is what happened in this case. This provokes for the github action to think there's no new stable version and it doesn't auto publish it.